### PR TITLE
Update style.css to have horizontal scrolling for long URLs

### DIFF
--- a/template/css/style.css
+++ b/template/css/style.css
@@ -172,6 +172,7 @@ pre {
   border-radius: 6px;
   position: relative;
   margin: 10px 0 20px 0;
+  overflow-x: auto;
 }
 
 pre.prettyprint {


### PR DESCRIPTION
Although it is not recommended to have long URLs, but it can happen due to huge amount of parameters available.

Currently the URL will overflow out of the black rectangle box and appear 'invisible' due to white font on top of white background